### PR TITLE
Fix inconsistency between license tag in Cabal and the LICENSE file

### DIFF
--- a/double-conversion.cabal
+++ b/double-conversion.cabal
@@ -1,6 +1,6 @@
 name:           double-conversion
 version:        2.0.2.0
-license:        BSD3
+license:        BSD2
 license-file:   LICENSE
 homepage:       https://github.com/bos/double-conversion
 bug-reports:    https://github.com/bos/double-conversion/issues


### PR DESCRIPTION
The LICENSE file contains a BSD2 license, but the Cabal file claims it would be BSD3.