### PR TITLE
Prepare for ghc 9.4 (base 4.17) which removes MonadFail ST

### DIFF
--- a/Data/Double/Conversion/Internal/Text.hs
+++ b/Data/Double/Conversion/Internal/Text.hs
@@ -52,7 +52,7 @@ convert func len act val = runST go
 #endif
       size <- unsafeIOToST $ act (realToFrac val) ma
       when (size == -1) .
-        fail $ "Data.Double.Conversion.Text." ++ func ++
+        error $ "Data.Double.Conversion.Text." ++ func ++
                ": conversion failed (invalid precision requested)"
       frozen <- A.unsafeFreeze buf
       return $ Text frozen 0 (fromIntegral size)

--- a/Data/Double/Conversion/Internal/TextBuilder.hs
+++ b/Data/Double/Conversion/Internal/TextBuilder.hs
@@ -43,6 +43,6 @@ convert func len act val = writeN (fromIntegral len) $ \(A.MArray maBa) _ -> do
 #endif
     size <- unsafeIOToST $ act (realToFrac val) maBa
     when (size == -1) .
-        fail $ "Data.Double.Conversion.Text." ++ func ++
+        error $ "Data.Double.Conversion.Text." ++ func ++
                ": conversion failed (invalid precision requested)"
     return ()


### PR DESCRIPTION
See context and migration guide:

- https://github.com/haskell/core-libraries-committee/issues/33
- https://github.com/haskell/core-libraries-committee/pull/42

Thanks!