### PR TITLE
Link with libc++ on FreeBSD.

### DIFF
--- a/double-conversion.cabal
+++ b/double-conversion.cabal
@@ -72,7 +72,7 @@ library
   if impl(ghc >= 9.4)
     build-depends: system-cxx-std-lib == 1.0
 
-  elif os(darwin)
+  elif os(darwin) || os(freebsd)
     extra-libraries: c++
   elif os(windows)
     if arch(x86_64) && impl(ghc < 8.6.5)


### PR DESCRIPTION
This pull request fixes the build on FreeBSD, which now fails because it tries to link the wrong c++ library.

It has been tested successfully on FreeBSD 13.1 using ghc-9.2.5 built from the ports collection. I also verified that it still builds correctly on MacOS (darwin) Monterey 12.6.1 also using ghc-9.2.5 installed via ghcup.